### PR TITLE
Reduce redundant notifications

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,35 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "jsx": false
+        }
+    },
+    "rules": {
+        "indent": [
+            "error",
+            2
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "off",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    },
+    "globals": {
+        "chrome": true
+    },
+};

--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -196,8 +196,8 @@ document.addEventListener('DOMContentLoaded', () => {
   
   function createNotificationsAsNecessary(oldValue, newValue) {
     if (shouldIgnoreChanges(oldValue, newValue)) return;
-    createNewStatusNotificationifNecessary(oldValue, newValue);
-    createNewCommentNotificationifNecessary(oldValue, newValue);
+    createNewStatusNotificationIfNecessary(oldValue, newValue);
+    createNewCommentNotificationIfNecessary(oldValue, newValue);
   }
 
   function shouldIgnoreChanges(oldValue, newValue) {
@@ -206,13 +206,13 @@ document.addEventListener('DOMContentLoaded', () => {
     return false;
   }
 
-  function createNewStatusNotificationifNecessary(oldValue, newValue) {
+  function createNewStatusNotificationIfNecessary(oldValue, newValue) {
     if (newValue.status === "Unknown") return;
     let notificationId = `TabID:${newValue.tabId}:${newValue.status}`;
     _createNotification(notificationId, newValue.title, newValue.status);
   }
 
-  function createNewCommentNotificationifNecessary(oldValue, newValue) {
+  function createNewCommentNotificationIfNecessary(oldValue, newValue) {
     if (newValue.commentsCount === oldValue.commentsCount) return;
     let notificationId = `TabID:${newValue.tabId}:${newValue.commentsCount}`;
     _createNotification(notificationId, newValue.title, "New comment");

--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   function isPullRequest(url) {
-    return url.includes("https://github.com") && url.includes("/pull/")
+    return url.includes("https://github.com") && url.includes("/pull/");
   }
 
   function requestPRStatus(repo, number, tabId, lastModified) {
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     return makeRequest(url, lastModified).then(response => {
       saveLastModified(response.url, response.headers.get('Last-Modified'));
-      return response.status === 200 ? response.json() : Promise.resolve();
+      return response.status === 200 ? response.json() : new Promise.resolve();
     }).then(jsonData => {
       return getNotification(jsonData, tabId);
     });
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
       chrome.storage.local.get(null, localItems => {
         let copy = Object.assign({}, localItems);
 
-        for (var key in copy) {
+        for (let key in copy) {
           if (copy[key]["url"] === url) {
             copy[key]["lastModified"] = lastModified;
             chrome.storage.local.set(copy);
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
       'If-Modified-Since': ifModifiedSince || '',
     };
 
-    return fetch(url, {headers});
+    return fetch(url, { headers });
   }
 
   function getStatusImg(state) {
@@ -92,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
         sha: statusResult.head.sha,
         lastModified: statusResult.lastModified,
         commentsCount: statusResult.review_comments || 0,
-      }
+      };
     }
     return undefined;
   }
@@ -124,10 +124,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function deleteStatus(tabId) {
     chrome.storage.local.get(null, data => {
-      for (var key in data) {
+      for (let key in data) {
         if (data[key].tabId === tabId) {
-          chrome.storage.local.remove(key, () => {
-          })
+          chrome.storage.local.remove(key, () => {});
         }
       }
     });
@@ -139,7 +138,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function update() {
     chrome.storage.local.get(null, localItems => {
-      for (var key in localItems) {
+      for (let key in localItems) {
         let existingStatus = localItems[key];
         requestPRStatus(existingStatus.repoName, existingStatus.number, existingStatus.tabId, existingStatus.lastModified).then(updatedStatus => {
           if (updatedStatus && updatedStatus.status === "Pending") {
@@ -151,7 +150,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 statusToShow = "Review Required";
                 imageToShow = "assets/images/review-required.png";
               }
-              let copy = Object.assign(updatedStatus, {status: statusToShow, img: imageToShow});
+              let copy = Object.assign(updatedStatus, { status: statusToShow, img: imageToShow });
               updateStorage(copy);
             });
           } else if (updatedStatus) {
@@ -170,11 +169,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   chrome.notifications.onClicked.addListener(id => {
     let tabId = parseInt(id.split(":")[1]);
-    chrome.tabs.update(tabId, {"active": true, "selected": true});
+    chrome.tabs.update(tabId, { "active": true, "selected": true });
   });
 
   chrome.tabs.onRemoved.addListener((tabId, removeInfo) => {
-    deleteStatus(tabId)
+    deleteStatus(tabId);
   });
 
   chrome.webNavigation.onDOMContentLoaded.addListener(tab => {
@@ -202,13 +201,13 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   chrome.storage.onChanged.addListener((changes, namespace) => {
-    for (key in changes) {
-      var storageChange = changes[key];
+    for (let key in changes) {
+      let storageChange = changes[key];
       if (storageChange.newValue) {
         if (storageChange.newValue !== storageChange.oldValue) {
           if (storageChange.newValue.status !== "Unknown") {
             let notificationId = `TabID:${storageChange.newValue.tabId}:${storageChange.newValue.status}`;
-            _createNotification(notificationId, storageChange.newValue.title, storageChange.newValue.status || "{}")
+            _createNotification(notificationId, storageChange.newValue.title, storageChange.newValue.status || "{}");
           }
           if (storageChange.oldValue) {
             if (storageChange.newValue.commentsCount !== storageChange.oldValue.commentsCount) {

--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -201,37 +201,32 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   
   function createNotificationsAsNecessary(oldValue, newValue) {
-    if (shouldIgnoreChanges(oldValue, newValue)) {
-      return;
-    }
-    if (shouldCreateNewStatusNotification(oldValue, newValue)) {
-      let notificationId = `TabID:${newValue.tabId}:${newValue.status}`;
-      _createNotification(notificationId, newValue.title, newValue.status);
-    }
-    if (shouldCreateNewCommentNotification(oldValue, newValue)) {
-      let notificationId = `TabID:${newValue.tabId}:${newValue.commentsCount}`;
-      _createNotification(notificationId, newValue.title, "New comment");
-    }
+    if (shouldIgnoreChanges(oldValue, newValue)) return;
+    createNewStatusNotificationifNecessary(oldValue, newValue);
+    createNewCommentNotificationifNecessary(oldValue, newValue);
   }
 
   function shouldIgnoreChanges(oldValue, newValue) {
-    if (!newValue) return true;
+    if (!newValue || !oldValue) return true;
     if (newValue.status === oldValue.status) return true;
-    if (newValue.status === "Merged" && !oldValue.status) return true;
     return false;
   }
 
-  function shouldCreateNewStatusNotification(oldValue, newValue) {
-    return newValue.status !== "Unknown";
+  function createNewStatusNotificationifNecessary(oldValue, newValue) {
+    if (newValue.status === "Unknown") return;
+    let notificationId = `TabID:${newValue.tabId}:${newValue.status}`;
+    _createNotification(notificationId, newValue.title, newValue.status);
   }
 
-  function shouldCreateNewCommentNotification(oldValue, newValue) {
-    return newValue.commentsCount !== oldValue.commentsCount;
+  function createNewCommentNotificationifNecessary(oldValue, newValue) {
+    if (newValue.commentsCount === oldValue.commentsCount) return;
+    let notificationId = `TabID:${newValue.tabId}:${newValue.commentsCount}`;
+    _createNotification(notificationId, newValue.title, "New comment");
   }
 
-  chrome.storage.onChanged.addListener((changes, namespace) => {
+  chrome.storage.onChanged.addListener(changes => {
     for (let key in changes) {
-      let { oldValue = {}, newValue } = changes[key];
+      let { oldValue, newValue } = changes[key];
       createNotificationsAsNecessary(oldValue, newValue);
     }
   });

--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -155,6 +155,39 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  function createNotificationsIfNecessary(oldValue, newValue) {
+    if (shouldIgnoreChanges(oldValue, newValue)) return;
+    createNewStatusNotificationIfNecessary(oldValue, newValue);
+    createNewCommentNotificationIfNecessary(oldValue, newValue);
+  }
+
+  function shouldIgnoreChanges(oldValue, newValue) {
+    if (!newValue || !oldValue) return true;
+    if (newValue.status === oldValue.status) return true;
+    return false;
+  }
+
+  function createNewStatusNotificationIfNecessary(oldValue, newValue) {
+    if (newValue.status === "Unknown") return;
+    let notificationId = `TabID:${newValue.tabId}:${newValue.status}`;
+    _createNotification(notificationId, newValue.title, newValue.status);
+  }
+
+  function createNewCommentNotificationIfNecessary(oldValue, newValue) {
+    if (newValue.commentsCount === oldValue.commentsCount) return;
+    let notificationId = `TabID:${newValue.tabId}:${newValue.commentsCount}`;
+    _createNotification(notificationId, newValue.title, "New comment");
+  }
+
+  function _createNotification(notificationId, title, message = "{}") {
+    chrome.notifications.create(notificationId, {
+      type: 'basic',
+      iconUrl: 'assets/images/icon-lg.png',
+      title: title,
+      message: message,
+    });
+  }
+
   chrome.alarms.create({
     periodInMinutes: 1
   });
@@ -185,43 +218,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  function _createNotification(notificationId, title, message = "{}") {
-    chrome.notifications.create(notificationId, {
-      type: 'basic',
-      iconUrl: 'assets/images/icon-lg.png',
-      title: title,
-      message: message,
-    });
-  }
-  
-  function createNotificationsAsNecessary(oldValue, newValue) {
-    if (shouldIgnoreChanges(oldValue, newValue)) return;
-    createNewStatusNotificationIfNecessary(oldValue, newValue);
-    createNewCommentNotificationIfNecessary(oldValue, newValue);
-  }
-
-  function shouldIgnoreChanges(oldValue, newValue) {
-    if (!newValue || !oldValue) return true;
-    if (newValue.status === oldValue.status) return true;
-    return false;
-  }
-
-  function createNewStatusNotificationIfNecessary(oldValue, newValue) {
-    if (newValue.status === "Unknown") return;
-    let notificationId = `TabID:${newValue.tabId}:${newValue.status}`;
-    _createNotification(notificationId, newValue.title, newValue.status);
-  }
-
-  function createNewCommentNotificationIfNecessary(oldValue, newValue) {
-    if (newValue.commentsCount === oldValue.commentsCount) return;
-    let notificationId = `TabID:${newValue.tabId}:${newValue.commentsCount}`;
-    _createNotification(notificationId, newValue.title, "New comment");
-  }
-
   chrome.storage.onChanged.addListener(changes => {
     for (let key in changes) {
       let { oldValue, newValue } = changes[key];
-      createNotificationsAsNecessary(oldValue, newValue);
+      createNotificationsIfNecessary(oldValue, newValue);
     }
   });
 


### PR DESCRIPTION
Notifications would appear immediately when a PR opened in a new tab, even if the status of it hadn't changed. This changes it so notifications are only created when a change was made while the tab is open.