### PR TITLE
Make functional with non-github.com sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@
 Whenever a tab is open with a pull request, the background page requests the status of the PR and its head commit from the Github API using your access token to authenticate.
 
 It stores the status and the last modified timestamp, and then polls the status API every minute to check for new updates. Since we are using the 'If Modified Since' header, any response that is a 304 Not Modified does not count towards API rate limits.
+
+## For Github Enterprise
+After cloning the repository, edit the manifest.json's github_url field to your git enterprise url (no leading http/https).
+
+When creating an access token, copy from your git enterprise settings rather than through the provided link. Make sure to add the `repo` permission as well as `notification`.
+
+All other steps are as normal.

--- a/extension/assets/css/popup.css
+++ b/extension/assets/css/popup.css
@@ -78,9 +78,6 @@ a.center {
   height: 12px;
   line-height: 12px;
 }
-.container {
-  height: 30px;
-}
 .blocked {
   color: red;
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -31,5 +31,6 @@
   "options_ui": {
     "page": "options.html",
     "chrome_style": true
-  }
+  },
+  "github_url": "github.com"
 }

--- a/extension/options.html
+++ b/extension/options.html
@@ -12,6 +12,7 @@
         <label for="access-token">Access Token</label>
         <input type="text" id="access-token">
         <span class="description"><a href="https://github.com/settings/tokens/new?scopes=notifications&description=Notifier for GitHub Chrome extension" target="gh_target">create a token</a> with the <strong>notifications</strong> permission and paste it here.</span><br />
+		    <br /><i>For github enterprise, etc, get your token manually + add the repo permission</i>
       </section>
       <section>
         <button class="btn btn-primary" type="submit">Save</button>

--- a/extension/scripts/popup.js
+++ b/extension/scripts/popup.js
@@ -29,8 +29,9 @@ function renderSetting() {
 }
 
 function _openSettings() {
-  const url = `chrome://extensions/?options=${chrome.runtime.id}`;
-  chrome.tabs.create({'url': url});
+  	const github_url = chrome.runtime.getManifest().github_url;
+    const url = `chrome://extensions/?options=${chrome.runtime.id}&github_url=${github_url}`;
+    chrome.tabs.create({ url: url, active: false });
 }
 
 function renderStatuses(notifications) {


### PR DESCRIPTION
I couldn't figure out how to change the popup for setting tokens, but I've verified this works with other GitHub addresses. (e.g. github enterprise)

Note: You can't have it enabled on both github and non-github sites at the same time (unless you make multiple copies of the extension i guess)

Also: Fixed some css on the popup